### PR TITLE
Add missing exporters to default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cert-exporter`
+- Add `net-exporter`
+- Add `node-exporter`
+
 ## [0.0.9] - 2023-01-24
 
 ### Changed

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -44,6 +44,7 @@ userConfig:
             "node-role.kubernetes.io/control-plane": '""'
 
   # What should we set here ? on Azure we get an hardware clock for chrony ntp
+  # By default it uses flatcar ntp endpoints
   # netExporter:
   #   configMap:
   #     values: |


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/24592

This PR:

- add `cert-exporter`
- add `net-exporter`
- add `node-exporter` 

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
