### PR TITLE
Bump Observability Bundle to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `vertical-pod-autoscaler-app` to 3.4.1 to address PDB on single replicas pods issue
+- Bump `observability-bundle` to 0.4.0
+
+### Removed
+
+- Remove kube-state-metrics app as it is now included in the observability-bundle.
 
 ## [0.0.15] - 2023-04-05
 

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -243,40 +243,6 @@
                         }
                     }
                 },
-                "kubeStateMetrics": {
-                    "type": "object",
-                    "properties": {
-                        "appName": {
-                            "type": "string"
-                        },
-                        "catalog": {
-                            "type": "string"
-                        },
-                        "chartName": {
-                            "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "metricsServer": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -145,18 +145,6 @@ apps:
     # used by renovate
     # repo: giantswarm/external-dns-app
     version: 2.33.0
-  kubeStateMetrics:
-    appName: kube-state-metrics
-    chartName: kube-state-metrics
-    catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/kube-state-metrics-app
-    version: 1.14.2
   metricsServer:
     appName: metrics-server
     chartName: metrics-server-app
@@ -205,7 +193,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.2.0
+    version: 0.4.0
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26221

### What this PR does / why we need it

This PR bumps the observability bundle and remove kube-state-metrics as it is now included

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests
/run cluster-test-suites
