### PR TITLE
Bump observability-bundle to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `observability-bundle` to 0.4.2
+
 ## [0.0.16] - 2023-04-18
 
 ### Changed
 
 - Update `vertical-pod-autoscaler-app` to 3.4.1 to address PDB on single replicas pods issue
-- Bump `observability-bundle` to 0.4.1
 
 ### Removed
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -193,7 +193,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.1
+    version: 0.4.2
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

towards https://github.com/giantswarm/giantswarm/issues/26674

Bump observability-bundle to 0.4.2: fix preStop with removing the wal directory in the prometheus-agent

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
