### PR TITLE
enable kube proxy cilium replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `observability-bundle` to 0.4.2
 - :boom: Breaking - Update `Cilium Values` to enable `kube-proxy-replacement` 
   - This change also require `cluster-azure` app >= 0.0.21
+- Bump `cilium-app` to 0.9.3
 
 ## [0.0.16] - 2023-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `observability-bundle` to 0.4.2
+- :boom: Breaking - Update `Cilium Values` to enable `kube-proxy-replacement` 
+  - This change also require `cluster-azure` app >= 0.0.21
 
 ## [0.0.16] - 2023-04-18
 

--- a/helm/default-apps-azure/ci/test-values.yaml
+++ b/helm/default-apps-azure/ci/test-values.yaml
@@ -1,1 +1,3 @@
 clusterName: test
+managementCluster: mc-test
+baseDomain: azuretest.example.io

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,8 +23,8 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # For WC the basedomain rendering of the ConfigMap does not include the clusterName but it does for MC
-        k8sServiceHost: api.{{ '' (printf '%s.' .Values.clusterName) (eq .Values.clusterName .Values.managementCluster) }}{{ .Values.baseDomain }}
+        # The balue of baseDomain is not consistent between MC and WC - until we fix that we need to add the cluster name when the value is being redenred for a WC
+        k8sServiceHost: api.{{ternary "" (print .Values.clusterName ".") (eq .Values.clusterName .Values.managementCluster)}}{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict
         hubble:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,9 +23,8 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # The value of baseDomain is not consistent between MC and WC - until we fix that we need to add the cluster name when the value is being redenred for a WC
-        # see https://github.com/giantswarm/giantswarm/issues/25360#issuecomment-1531221382
-        k8sServiceHost: apiserver.{{ternary "" (print .Values.clusterName ".") (eq .Values.clusterName .Values.managementCluster)}}{{ .Values.baseDomain }}
+        # baseDomain **must be Fully qualified** `CLUSTER_NAME.azuretest.gigantic.io` 
+        k8sServiceHost: apiserver.{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict
         hubble:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,7 +23,8 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # The balue of baseDomain is not consistent between MC and WC - until we fix that we need to add the cluster name when the value is being redenred for a WC
+        # The value of baseDomain is not consistent between MC and WC - until we fix that we need to add the cluster name when the value is being redenred for a WC
+        # see https://github.com/giantswarm/giantswarm/issues/25360#issuecomment-1531221382
         k8sServiceHost: api.{{ternary "" (print .Values.clusterName ".") (eq .Values.clusterName .Values.managementCluster)}}{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -24,7 +24,7 @@ userConfig:
         ipam:
           mode: kubernetes
         # For WC the basedomain rendering of the ConfigMap does not include the clusterName but it does for MC
-        k8sServiceHost: api.{{ "" (printf "%s." .Values.clusterName) (eq .Values.clusterName .Values.managementCluster) }}{{ .Values.baseDomain }}
+        k8sServiceHost: api.{{ '' (printf '%s.' .Values.clusterName) (eq .Values.clusterName .Values.managementCluster) }}{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict
         hubble:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,8 +23,8 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # TODO: Check this works for both MC and WC
-        k8sServiceHost: api.{{ .Values.baseDomain }}
+        # For WC the basedomain rendering of the ConfigMap does not include the clusterName but it does for MC
+        k8sServiceHost: api.{{ "" (printf "%s." .Values.clusterName) (eq .Values.clusterName .Values.managementCluster) }}{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict
         hubble:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,6 +23,10 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
+        # TODO: Check this works for both MC and WC 
+        k8sServiceHost: api.{{ .Values.baseDomain }}
+        k8sServicePort: "6443"
+        kubeProxyReplacement: strict
         hubble:
           relay:
             enabled: true
@@ -120,7 +124,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cilium-app
-    version: 0.6.1
+    version: 0.9.3
   coreDNS:
     appName: coredns
     chartName: coredns-app

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,7 +23,7 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # baseDomain **must be Fully qualified** `CLUSTER_NAME.azuretest.gigantic.io` 
+        # baseDomain **must be Fully qualified** `CLUSTER_NAME.azuretest.gigantic.io`
         k8sServiceHost: apiserver.{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -23,7 +23,7 @@ userConfig:
       values: |
         ipam:
           mode: kubernetes
-        # TODO: Check this works for both MC and WC 
+        # TODO: Check this works for both MC and WC
         k8sServiceHost: api.{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -25,7 +25,7 @@ userConfig:
           mode: kubernetes
         # The value of baseDomain is not consistent between MC and WC - until we fix that we need to add the cluster name when the value is being redenred for a WC
         # see https://github.com/giantswarm/giantswarm/issues/25360#issuecomment-1531221382
-        k8sServiceHost: api.{{ternary "" (print .Values.clusterName ".") (eq .Values.clusterName .Values.managementCluster)}}{{ .Values.baseDomain }}
+        k8sServiceHost: apiserver.{{ternary "" (print .Values.clusterName ".") (eq .Values.clusterName .Values.managementCluster)}}{{ .Values.baseDomain }}
         k8sServicePort: "6443"
         kubeProxyReplacement: strict
         hubble:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25360

- enable kube proxy replacement and update cilium to latest version
- Update cilium to 0.9.3 

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
