### PR TITLE
With upgraded coredns ( already merged ) we don't need custom selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `observability-bundle` to 0.4.2
+- Bump `vertical-pod-autoscaler` to 3.4.2
+- Bump `node-exporter` to 1.16.0
+- Bump `net-exporter` to 1.15.0
+- Bump `metrics-server` to 2.2.0
+- Bump `cert-exporter` to 2.5.1
+- Bump `azuredisk-csi-driver` to 1.26.2-gs2
+- Bump `coredns-app` to 1.16.0
+  - Remove custom nodeSelector for coredns since is no longer required
 
 ## [0.0.16] - 2023-04-18
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -35,13 +35,6 @@ userConfig:
               operator: Exists
             - key: CriticalAddonsOnly
               operator: Exists
-  coreDNS:
-    configMap:
-      values: |
-        mastersInstance:
-          nodeSelector:
-            "node-role.kubernetes.io/master": null
-            "node-role.kubernetes.io/control-plane": '""'
 
   external-dns:
     configMap:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Update Changelog with all the missing updates from renovate
- Remove the nodeSelector for control plane coredns since is not required anymore and actually breaks the workload

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
