### PR TITLE
disable seccomp vpa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- :boom: Disable `Seccomp` for VPA since is preventing pods from starting
+  - This will be reverted once the problem is fixed
+
 ## [0.0.18] - 2023-05-17
 
 ### Changed

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -54,10 +54,21 @@ userConfig:
   vpa:
     configMap:
       values: |
-        podSecurityContext:
-          runAsNonRoot: true
-          runAsUser: 65534
-        securityContext: null
+        vertical-pod-autoscaler:
+          podSecurityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+          securityContext: null
+        recommender:
+          podSecurityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+          securityContext: null
+        updater:
+          podSecurityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+          securityContext: null
 
 apps:
   azure-cloud-controller-manager:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -49,13 +49,13 @@ userConfig:
         crd:
           install: false
 
-  # What should we set here ? on Azure we get an hardware clock for chrony ntp
-  # By default it uses flatcar ntp endpoints
-  # netExporter:
-  #   configMap:
-  #     values: |
-  #       NetExporter:
-  #         NTPServers: 169.254.169.123
+  vpa:
+    configMap:
+      values: |
+        podSecurityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+        securityContext: null
 
 apps:
   azure-cloud-controller-manager:
@@ -195,6 +195,9 @@ apps:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app
     catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
     dependsOn: vertical-pod-autoscaler-crd
     forceUpgrade: false
     namespace: kube-system

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -55,20 +55,21 @@ userConfig:
     configMap:
       values: |
         vertical-pod-autoscaler:
-          podSecurityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-          securityContext: null
-        recommender:
-          podSecurityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-          securityContext: null
-        updater:
-          podSecurityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-          securityContext: null
+          admissionController:
+            podSecurityContext:
+              runAsNonRoot: true
+              runAsUser: 65534
+            securityContext: null
+          recommender:
+            podSecurityContext:
+              runAsNonRoot: true
+              runAsUser: 65534
+            securityContext: null
+          updater:
+            podSecurityContext:
+              runAsNonRoot: true
+              runAsUser: 65534
+            securityContext: null
 
 apps:
   azure-cloud-controller-manager:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -49,6 +49,8 @@ userConfig:
         crd:
           install: false
 
+  # Disable SECCOMP for VPA since it prevents pods from starting - TO BE REVERTED
+  # https://gigantic.slack.com/archives/C01176DKNP4/p1684395585121689
   vpa:
     configMap:
       values: |

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -59,16 +59,19 @@ userConfig:
             podSecurityContext:
               runAsNonRoot: true
               runAsUser: 65534
+              seccompProfile: null
             securityContext: null
           recommender:
             podSecurityContext:
               runAsNonRoot: true
               runAsUser: 65534
+              seccompProfile: null
             securityContext: null
           updater:
             podSecurityContext:
               runAsNonRoot: true
               runAsUser: 65534
+              seccompProfile: null
             securityContext: null
 
 apps:


### PR DESCRIPTION
- Try to disable seccomp for VPA since it preventing pods from starting
- Update changelog and add comment

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
