### PR TITLE
Revert workaround for seccomp on VPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Remove workaround for VPA Seccomp 
-  - requires PSP from `cluster-shared v0.6.5` - :boom: requires cluster-azure 0.0.23
+- :boom: Remove workaround for VPA Seccomp 
+  - requires PSP from `cluster-shared v0.6.5` which ships with `cluster-azure 0.0.23`
 - Bump `azure-cloud-controller-manager` to 1.24.18-gs4
   - Remove custom nodeSelector 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove workaround for VPA Seccomp 
+  - requires PSP from `cluster-shared v0.6.5`
 - Bump `azure-cloud-controller-manager` to 1.24.18-gs4
   - Remove custom nodeSelector 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove workaround for VPA Seccomp 
-  - requires PSP from `cluster-shared v0.6.5`
+  - requires PSP from `cluster-shared v0.6.5` - :boom: requires cluster-azure 0.0.23
 - Bump `azure-cloud-controller-manager` to 1.24.18-gs4
   - Remove custom nodeSelector 
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -46,31 +46,6 @@ userConfig:
         crd:
           install: false
 
-  # Disable SECCOMP for VPA since it prevents pods from starting - TO BE REVERTED
-  # https://gigantic.slack.com/archives/C01176DKNP4/p1684395585121689
-  vpa:
-    configMap:
-      values: |
-        vertical-pod-autoscaler:
-          admissionController:
-            podSecurityContext:
-              runAsNonRoot: true
-              runAsUser: 65534
-              seccompProfile: null
-            securityContext: null
-          recommender:
-            podSecurityContext:
-              runAsNonRoot: true
-              runAsUser: 65534
-              seccompProfile: null
-            securityContext: null
-          updater:
-            podSecurityContext:
-              runAsNonRoot: true
-              runAsUser: 65534
-              seccompProfile: null
-            securityContext: null
-
 apps:
   azure-cloud-controller-manager:
     appName: azure-cloud-controller-manager


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27124

This PR:

- removes the workaroung used to disable seccomp profiles on VPA 

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [x] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [x] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
