### PR TITLE
update cert exporter to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - requires PSP from `cluster-shared v0.6.5` which ships with `cluster-azure 0.0.23`
 - Bump `azure-cloud-controller-manager` to 1.24.18-gs4
   - Remove custom nodeSelector 
+- Bump `cert-exporter` to 2.6.0
 
 ## [0.0.19] - 2023-05-18
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -94,7 +94,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-exporter
-    version: 2.5.1
+    version: 2.6.0
   cilium:
     appName: cilium
     chartName: cilium


### PR DESCRIPTION
- update cert-exporter to 2.6.0

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
