### PR TITLE
etcd-kubernetes-resources-count-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `etcd-kubernetes-resources-count-exporter`.
+
 ## [0.0.22] - 2023-06-06
 
 ### Changed

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -141,6 +141,40 @@
                         }
                     }
                 },
+                "certManager": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "cilium": {
                     "type": "object",
                     "properties": {
@@ -176,6 +210,40 @@
                     }
                 },
                 "coreDNS": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -394,6 +462,17 @@
                         "chartName": {
                             "type": "string"
                         },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "dependsOn": {
                             "type": "string"
                         },
@@ -468,6 +547,19 @@
                         }
                     }
                 },
+                "certManager": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "cilium": {
                     "type": "object",
                     "properties": {
@@ -481,7 +573,7 @@
                         }
                     }
                 },
-                "coreDNS": {
+                "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {
                         "configMap": {

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -48,6 +48,15 @@ userConfig:
             - key: CriticalAddonsOnly
               operator: Exists
 
+  etcdKubernetesResourceCountExporter:
+    configMap:
+      values: |
+        etcd:
+          hostPath: "/etc/kubernetes/pki/etcd/"
+          cacertpath: "/certs/ca.crt"
+          certpath: "/certs/server.crt"
+          keypath: "/certs/server.key"
+
   external-dns:
     configMap:
       values: |
@@ -142,6 +151,18 @@ apps:
     # used by renovate
     # repo: giantswarm/coredns-app
     version: 1.17.0
+  etcdKubernetesResourceCountExporter:
+    appName: etcd-kubernetes-resources-count-exporter
+    chartName: etcd-kubernetes-resources-count-exporter
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/etcd-kubernetes-resources-count-exporter
+    version: 1.3.0
   external-dns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/25482

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites