### PR TITLE
Update cert-manager-app values for upcoming major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `etcd-kubernetes-resources-count-exporter`.
+- Update `cert-manager-app` values in preparation of v3.0.0 release.
 
 ### Changed
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -18,6 +18,7 @@ userConfig:
   certManager:
     configMap:
       values: |
+        # cert-manager-app v2.x.x
         controller:
           extraArgs:
             # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
@@ -26,6 +27,13 @@ userConfig:
             #
             # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
             - --dns01-recursive-nameservers-only
+        # cert-manager-app v3.x.x
+        # cert-manager's DNS01 solver by default tries to reach authoritative nameservers directly, using
+        # their public IPs. Since those are not reachable from private clusters, we instead rely on the
+        # recursive nameserver
+        #
+        # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
+        dns01RecursiveNameserversOnly: true
   cilium:
     configMap:
       values: |


### PR DESCRIPTION
### What this PR does / why we need it

Upcoming cert-manager-app major contains a breaking change in the values. This PR updates the default-app values to work on both v2.x.x and v3.x.x

Towards https://github.com/giantswarm/giantswarm/issues/27604

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
