### PR TITLE
Set explicit config for external-dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `external-dns` config for upgrade to v3.
+
 ## [0.0.24] - 2023-08-03
 
 ### Changed

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -40,7 +40,20 @@ userConfig:
         clusterID: {{ .Values.clusterName }}
         crd:
           install: false
-
+        domainFilters:
+          - {{ .Values.baseDomain }}
+        txtOwnerId: giantswarm-io-external-dns
+        txtPrefix: {{ .Values.clusterName }}
+        sources:
+          - service
+        extraVolumes:
+          - name: azure-config-file
+            hostPath:
+              path: /etc/kubernetes
+        extraVolumeMounts:
+          - name: azure-config-file
+            mountPath: /etc/kubernetes
+            readOnly: true
 apps:
   certExporter:
     appName: cert-exporter


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Sets explicitly some options in external-dns config to allow migration to v3.

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
