### PR TITLE
Reduce k8s resource count exporter app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Shortened `etcd-kubernetes-resources-count-exporter` appName to `etcd-k8s-res-count-exporter`.
+
 ## [0.4.0] - 2023-11-20
 
 ## [0.3.0] - 2023-10-09

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -85,7 +85,7 @@ apps:
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
   etcdKubernetesResourceCountExporter:
-    appName: etcd-kubernetes-resources-count-exporter
+    appName: etcd-k8s-res-count-exporter
     chartName: etcd-kubernetes-resources-count-exporter
     catalog: default
     clusterValues:


### PR DESCRIPTION
This reduces the etcd-kubernetes-resources-count-exporter appName that was causing the default-apps installation to fail in clusters having longer names.

Towards https://github.com/giantswarm/giantswarm/issues/28911

Same PR for CAPA: https://github.com/giantswarm/default-apps-aws/pull/361

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
