### PR TITLE
fix-psp-values-for-observability-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix psp values for observability-bundle > 1.0.0.
+
 ## [0.8.0] - 2024-01-15
 
 ### Changed

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -46,6 +46,39 @@ userConfig:
           - name: azure-config-file
             mountPath: /etc/kubernetes
             readOnly: true
+  observabilityBundle:
+    configMap:
+      values: |
+        userConfig:
+          kubePrometheusStack:
+            configMap:
+              values:
+                global:
+                  rbac:
+                    pspEnabled: true
+                kube-prometheus-stack:
+                  grafana:
+                    rbac:
+                      pspEnabled: true
+                  kube-state-metrics:
+                    podSecurityPolicy:
+                      enabled: true
+                  prometheus-node-exporter:
+                    rbac:
+                      pspEnabled: true
+          prometheusAgent:
+            configMap:
+              values:
+                prometheus-agent:
+                  psp:
+                    enabled: true
+          promtail:
+            configMap:
+              values:
+                promtail:
+                  rbac:
+                    pspEnabled: true
+
 apps:
   certExporter:
     appName: cert-exporter


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/29529

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
