### PR TITLE
Add second external-dns for private clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add second external-dns app for private clusters.
+
 ## [0.10.0] - 2024-02-21
 
 ### Changed

--- a/helm/default-apps-azure/README.md
+++ b/helm/default-apps-azure/README.md
@@ -4,8 +4,7 @@ This page lists all available configuration options, based on the [configuration
 
 <!-- DOCS_START -->
 
-### Apps
-
+### 
 Properties within the `.apps` top-level object
 
 | **Property** | **Description** | **More Details** |
@@ -51,16 +50,26 @@ Properties within the `.apps` top-level object
 | `apps.etcdKubernetesResourceCountExporter.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
 | `apps.etcdKubernetesResourceCountExporter.namespace` |**None**|**Type:** `string`<br/>|
 | `apps.etcdKubernetesResourceCountExporter.version` |**None**|**Type:** `string`<br/>|
-| `apps.external-dns` |**None**|**Type:** `object`<br/>|
-| `apps.external-dns.appName` |**None**|**Type:** `string`<br/>|
-| `apps.external-dns.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.external-dns.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.external-dns.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.external-dns.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.external-dns.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.external-dns.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.external-dns.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.external-dns.version` |**None**|**Type:** `string`<br/>|
+| `apps.externalDns` |**None**|**Type:** `object`<br/>|
+| `apps.externalDns.appName` |**None**|**Type:** `string`<br/>|
+| `apps.externalDns.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.externalDns.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.externalDns.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.externalDns.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDns.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDns.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDns.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.externalDns.version` |**None**|**Type:** `string`<br/>|
+| `apps.externalDnsPrivate` |**None**|**Type:** `object`<br/>|
+| `apps.externalDnsPrivate.appName` |**None**|**Type:** `string`<br/>|
+| `apps.externalDnsPrivate.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.externalDnsPrivate.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.externalDnsPrivate.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.externalDnsPrivate.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDnsPrivate.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDnsPrivate.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.externalDnsPrivate.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.externalDnsPrivate.version` |**None**|**Type:** `string`<br/>|
 | `apps.metricsServer` |**None**|**Type:** `object`<br/>|
 | `apps.metricsServer.appName` |**None**|**Type:** `string`<br/>|
 | `apps.metricsServer.catalog` |**None**|**Type:** `string`<br/>|
@@ -127,21 +136,30 @@ Properties within the `.apps` top-level object
 | `apps.vpa.namespace` |**None**|**Type:** `string`<br/>|
 | `apps.vpa.version` |**None**|**Type:** `string`<br/>|
 
-### User Config
+### 
+Properties within the `.cluster` top-level object
 
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `cluster.private` |**None**|**Type:** `boolean`<br/>|
+
+### 
 Properties within the `.userConfig` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `userConfig.certManager` |**None**|**Type:** `object`<br/>|
 | `userConfig.certManager.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.certManager.configMap.values` |**None**|**Type:** `string`<br/>|
+| `userConfig.certManager.configMap.values` |**None**|**Types:** `object, string`<br/>|
 | `userConfig.etcdKubernetesResourceCountExporter` |**None**|**Type:** `object`<br/>|
 | `userConfig.etcdKubernetesResourceCountExporter.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.etcdKubernetesResourceCountExporter.configMap.values` |**None**|**Type:** `string`<br/>|
-| `userConfig.external-dns` |**None**|**Type:** `object`<br/>|
-| `userConfig.external-dns.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.external-dns.configMap.values` |**None**|**Type:** `string`<br/>|
+| `userConfig.etcdKubernetesResourceCountExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.externalDns` |**None**|**Type:** `object`<br/>|
+| `userConfig.externalDns.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.externalDns.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.externalDnsPrivate` |**None**|**Type:** `object`<br/>|
+| `userConfig.externalDnsPrivate.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.externalDnsPrivate.configMap.values` |**None**|**Types:** `object, string`<br/>|
 
 ### Other
 
@@ -149,5 +167,7 @@ Properties within the `.userConfig` top-level object
 | :----------- | :-------------- | :--------------- |
 | `clusterName` |**None**|**Type:** `string`<br/>|
 | `organization` |**None**|**Type:** `string`<br/>|
+
+
 
 <!-- DOCS_END -->

--- a/helm/default-apps-azure/templates/apps.yaml
+++ b/helm/default-apps-azure/templates/apps.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $value := .Values.apps }}
 {{- $appName := .appName }}
-{{- if .enabled }}
+{{- if eq (tpl (.enabled | toString) $) "true" }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -144,7 +144,41 @@
                         }
                     }
                 },
-                "external-dns": {
+                "externalDns": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "externalDnsPrivate": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -400,6 +434,14 @@
                 }
             }
         },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "private":{
+                    "type": "boolean"
+                }
+            }
+        },
         "clusterName": {
             "type": "string"
         },
@@ -435,7 +477,20 @@
                         }
                     }
                 },
-                "external-dns": {
+                "externalDns": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": ["object", "string"]
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDnsPrivate": {
                     "type": "object",
                     "properties": {
                         "configMap": {

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -1,6 +1,11 @@
 clusterName: ""
 organization: ""
 
+# filled by cluster-apps-operator
+# via <cluster-name>-cluster-values configmap
+cluster:
+  private: false
+
 userConfig:
   certManager:
     configMap:
@@ -24,11 +29,31 @@ userConfig:
           prefix: "/registry/"
         events:
           prefix: "/registry/events/"
-  external-dns:
+  externalDns:
     configMap:
       values:
-        flavor: capi
         provider: azure
+        clusterID: "{{ .Values.clusterName }}"
+        crd:
+          install: false
+        domainFilters:
+          - "{{ .Values.baseDomain }}"
+        txtOwnerId: giantswarm-io-external-dns
+        txtPrefix: "{{ .Values.clusterName }}"
+        sources:
+          - service
+        extraVolumes:
+          - name: azure-config-file
+            hostPath:
+              path: /etc/kubernetes
+        extraVolumeMounts:
+          - name: azure-config-file
+            mountPath: /etc/kubernetes
+            readOnly: true
+  externalDnsPrivate:
+    configMap:
+      values:
+        provider: azure-private-dns
         clusterID: "{{ .Values.clusterName }}"
         crd:
           install: false
@@ -102,7 +127,7 @@ apps:
     # used by renovate
     # repo: giantswarm/etcd-kubernetes-resources-count-exporter
     version: 1.9.0
-  external-dns:
+  externalDns:
     appName: external-dns
     chartName: external-dns-app
     catalog: default
@@ -111,6 +136,19 @@ apps:
       secret: false
     dependsOn: prometheus-operator-crd
     enabled: true
+    forceUpgrade: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/external-dns-app
+    version: 3.1.0
+  externalDnsPrivate:
+    appName: external-dns-private
+    chartName: external-dns-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    enabled: "{{ $.Values.cluster.private }}"
     forceUpgrade: true
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29803

For private clusters, we have 2 DNS zone. One is private and one is public. We need to deploy 2 instance of external-dns to keep both in sync.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
