### PR TITLE
Add dependencies on `prometheus-operator-crd` for quicker deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add dependencies on `prometheus-operator-crd` for quicker deployment
+
 ## [0.8.1] - 2024-01-17
 
 ### Fixed

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -87,6 +87,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -99,6 +100,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    dependsOn: prometheus-operator-crd
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -136,6 +138,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -160,6 +163,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -172,12 +176,14 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/node-exporter-app
     version: 1.18.1
   observabilityBundle:
+    # Includes prometheus-operator-crd
     appName: observability-bundle
     chartName: observability-bundle
     catalog: default
@@ -197,6 +203,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
@@ -230,6 +237,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: prometheus-operator-crd
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Introduce a dependency for apps that use a `ServiceMonitor` CR which is installed by `prometheus-operator-crd`. 

Found by chance while checking in https://github.com/giantswarm/default-apps-azure/pull/202 why E2E tests failed. The dependency fix could improve deployment speed and therefore lead to fewer test errors, but that's only a guess. This also makes the dependencies more consistent with `default-apps-aws`.

### Trigger e2e tests

/run cluster-test-suites
