### PR TITLE
Adapt templates to respect "enabled" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adapt templates to be able to enable/disable apps. 
+
 ## [0.8.1] - 2024-01-17
 
 ### Fixed

--- a/helm/default-apps-azure/templates/apps.yaml
+++ b/helm/default-apps-azure/templates/apps.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $value := .Values.apps }}
 {{- $appName := .appName }}
+{{- if .enabled }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
@@ -98,5 +99,5 @@ stringData:
   {{- (tpl (.secret | toYaml | toString) $) | nindent 2 }}
 {{- end }}
 {{- end }}
-
+{{- end }}
 {{- end }}

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -87,6 +87,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -99,6 +100,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -124,6 +126,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate
@@ -136,6 +139,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -148,6 +152,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -160,6 +165,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -172,6 +178,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -184,6 +191,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
@@ -197,6 +205,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
@@ -210,6 +219,7 @@ apps:
     clusterValues:
       configMap: true
       secret: true
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
@@ -230,6 +240,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28860

We need this mechanism to be able to enable/disable a second external-dns according to the type of the cluster (`public/private`). 

See the usage of this flag https://github.com/giantswarm/default-apps-azure/pull/212

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.