### PR TITLE
Configure cert manager for private clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add second external-dns app for private clusters.
+- Add private cluster support for cert-manager.
 
 ## [0.10.0] - 2024-02-21
 

--- a/helm/default-apps-azure/templates/cert-manager-extra-config.yaml
+++ b/helm/default-apps-azure/templates/cert-manager-extra-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  values: |
+    {{- if $.Values.cluster.private }}
+    dns01RecursiveNameservers: "8.8.8.8:53,1.1.1.1:53"
+    giantSwarmClusterIssuer:
+      acme:
+        http01:
+          enabled: false
+        dns01:
+          azureDNS:
+            enabled: true
+            zoneName: "{{ .Values.baseDomain }}"
+            resourceGroupName: "{{ .Values.clusterName }}"
+            subscriptionID: "{{ .Values.subscriptionID }}"
+            identityClientID: "{{ .Values.identityClientID }}"
+    {{- end }}
+kind: ConfigMap
+metadata:
+  name: "{{ $.Values.clusterName }}-cert-manager-extra-config"
+  namespace: "{{ $.Release.Namespace }}"

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -434,6 +434,9 @@
                 }
             }
         },
+        "baseDomain": {
+            "type": "string"
+        },
         "cluster": {
             "type": "object",
             "properties": {
@@ -443,6 +446,12 @@
             }
         },
         "clusterName": {
+            "type": "string"
+        },
+        "identityClientID": {
+            "type": "string"
+        },
+        "subscriptionID": {
             "type": "string"
         },
         "organization": {

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -1,10 +1,15 @@
 clusterName: ""
 organization: ""
 
+# only necessary for management clusters
+identityClientID: ""
+
 # filled by cluster-apps-operator
 # via <cluster-name>-cluster-values configmap
+baseDomain: ""
 cluster:
   private: false
+subscriptionID: ""
 
 userConfig:
   certManager:
@@ -15,6 +20,9 @@ userConfig:
         # recursive nameserver
         #
         # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
+
+        # check extra config for private WC parameters
+        # note that user config has higher priority and extra config can be overwritten by userConfig
         dns01RecursiveNameserversOnly: true
         ciliumNetworkPolicy:
           enabled: true
@@ -101,6 +109,10 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 3.7.3
+    extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterName }}-cert-manager-extra-config"
+        namespace: "{{ $.Release.Namespace }}"
   chartOperatorExtensions:
     appName: chart-operator-extensions
     chartName: chart-operator-extensions


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28860

**How we will manage the new fields**
- identityClientID -> We need this for only MCs. We will set it in mc-bootstrap.
- baseDomain -> already set by cluster-apps-operator via cluster-values configmap
- cluster.private -> already set by cluster-apps-operator via cluster-values configmap
- subscriptionID -> I will add this to cluster-values configmap too by adapting cluster-apps-operator

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
