### PR TITLE
Re-enable PSPs for security-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Adapt templates to be able to enable/disable apps. 
+- Adapt templates to be able to enable/disable apps.
 - Add dependencies on `prometheus-operator-crd` for quicker deployment
 - Update observability-bundle to v1.2.1
+- Added values for security-bundle to re-enable PSPs
 
 ## [0.8.1] - 2024-01-17
 

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -46,6 +46,60 @@ userConfig:
           - name: azure-config-file
             mountPath: /etc/kubernetes
             readOnly: true
+  securityBundle:
+    configMap:
+      values: |
+        userConfig:
+          exceptionRecommender:
+            configMap:
+              values:
+                global:
+                  podSecurityStandards:
+                    enforced: false
+          falco:
+            configMap:
+              values:
+                global:
+                  podSecurityStandards:
+                    enforced: false
+                falco:
+                  falco-exporter:
+                    podSecurityPolicy:
+                      create: true
+          jiralert:
+            configMap:
+              values:
+                global:
+                  podSecurityStandards:
+                    enforced: false
+          kyverno:
+            configMap:
+              values:
+                global:
+                  podSecurityStandards:
+                    enforced: false
+          kyvernoPolicies:
+            configMap:
+              values:
+                kyverno-policies:
+                  validationFailureAction: Audit
+          kyvernoPolicyOperator:
+            configMap:
+              values:
+                global:
+                  podSecurityStandards:
+                    enforced: false
+          trivy:
+            configMap:
+              values:
+                trivy:
+                  rbac:
+                    pspEnabled: true
+          trivyOperator:
+            configMap:
+              values:
+                rbac:
+                  pspEnabled: true
 
 apps:
   certExporter:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Re-enables the use of PSPs within the security-bundle
- Fixes https://github.com/giantswarm/giantswarm/issues/29813

### Testing

Description on how default-apps-azure can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for default-apps-azure installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
