### PR TITLE
Add cilium-servicemonitors app as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cilium-servicemonitors` app.
+
 ### Changed
 
 - Add second external-dns app for private clusters.

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -110,6 +110,43 @@
                         }
                     }
                 },
+                "ciliumServiceMonitors": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -125,7 +125,7 @@ apps:
     dependsOn: prometheus-operator-crd
     namespace: kube-system
     # used by renovate
-    # repo: giantswarm/cilium-servicemonitors
+    # repo: giantswarm/cilium-servicemonitors-app
     version: 0.1.2
   etcdKubernetesResourceCountExporter:
     appName: etcd-k8s-res-count-exporter

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -114,6 +114,19 @@ apps:
     # used by renovate
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.2
+  ciliumServiceMonitors:
+    appName: cilium-servicemonitors
+    chartName: cilium-servicemonitors
+    catalog: default
+    enabled: true
+    clusterValues:
+      configMap: false
+      secret: false
+    dependsOn: prometheus-operator-crd
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/chart-operator-extensions
+    version: 0.1.2
   etcdKubernetesResourceCountExporter:
     appName: etcd-k8s-res-count-exporter
     chartName: etcd-kubernetes-resources-count-exporter

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -125,7 +125,7 @@ apps:
     dependsOn: prometheus-operator-crd
     namespace: kube-system
     # used by renovate
-    # repo: giantswarm/chart-operator-extensions
+    # repo: giantswarm/cilium-servicemonitors
     version: 0.1.2
   etcdKubernetesResourceCountExporter:
     appName: etcd-k8s-res-count-exporter


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR adds the cilium-servicemonitors app

Towards https://github.com/giantswarm/roadmap/issues/3283

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.
-->

/run cluster-test-suites
