### PR TITLE
Revert giantswarm/vertical-pod-autoscaler-app to 5.1.0

### DIFF
--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -319,4 +319,4 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-app
-    version: 5.2.1
+    version: 5.1.0


### PR DESCRIPTION
Similar to https://github.com/giantswarm/cluster/pull/155/files
See https://github.com/giantswarm/roadmap/issues/3421

/run cluster-test-suites
