### PR TITLE
Add flag to enable moving resource to cluster-azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+ - Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` that enables migration of apps from default-apps-azure to cluster-azure (apps are paused, so they are not removed from the WC when default-apps-azure is deleted).
+
 ### Changed
 
 - Update `net-exporter` to 1.19.0.

--- a/helm/default-apps-azure/templates/apps.yaml
+++ b/helm/default-apps-azure/templates/apps.yaml
@@ -11,6 +11,12 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
+    {{- if and $.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure (not .inCluster) }}
+    {{- /* We add pause annotation to all apps except bundles (.inCluster==true), because we
+            delete bundles from the MC in order to trigger correct deletion of bundled apps.
+    */}}
+    app-operator.giantswarm.io/paused: "true"
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}  

--- a/helm/default-apps-azure/templates/move-apps-to-cluster-azure.yaml
+++ b/helm/default-apps-azure/templates/move-apps-to-cluster-azure.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-azure
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: update-apps-release-name
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+
+          echo "Remove app-operator finalizer for all Apps owned by default-apps-azure (except bundles that we want to delete regularly)"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-azure,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
+            case "$app_name" in
+              *bundle*)
+                echo "do nothing for bundles"
+                ;;
+              *)
+                kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+                ;;
+            esac
+          done
+
+          echo "Remove app-operator finalizer from all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+
+          echo "Remove app-operator finalizer from all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+{{- end }}

--- a/helm/default-apps-azure/templates/propagate-pause-to-bundled-apps.yaml
+++ b/helm/default-apps-azure/templates/propagate-pause-to-bundled-apps.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-propagate-pause
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-propagate-pause
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-propagate-pause
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: update-apps-release-name
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+
+          echo "Add pause annotation to all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+
+          echo "Add pause annotation to all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+{{- end }}

--- a/helm/default-apps-azure/values.schema.json
+++ b/helm/default-apps-azure/values.schema.json
@@ -556,6 +556,18 @@
         "clusterName": {
             "type": "string"
         },
+        "deleteOptions": {
+            "type": "object",
+            "title": "Delete options",
+            "properties": {
+                "moveAppsHelmOwnershipToClusterAzure": {
+                    "type": "boolean",
+                    "title": "Move Apps Helm ownership to cluster-azure",
+                    "description": "Don't delete Apps (and their ConfigMaps) and update Helm `meta.helm.sh/release-name` annotation on all resources so they are owned by cluster-azure. That way cluster-azure can continue updating same resources that were previously created by default-apps-azure.",
+                    "default": false
+                }
+            }
+        },
         "identityClientID": {
             "type": "string"
         },

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -11,6 +11,9 @@ cluster:
   private: false
 subscriptionID: ""
 
+deleteOptions:
+   moveAppsHelmOwnershipToClusterAzure: false
+
 userConfig:
   certManager:
     configMap:

--- a/helm/default-apps-azure/values.yaml
+++ b/helm/default-apps-azure/values.yaml
@@ -12,7 +12,7 @@ cluster:
 subscriptionID: ""
 
 deleteOptions:
-   moveAppsHelmOwnershipToClusterAzure: false
+  moveAppsHelmOwnershipToClusterAzure: false
 
 userConfig:
   certManager:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3462

This PR adds a Helm boolean value that, when enabled, will create post-delete hook where all resources will have their `meta.helm.sh/release-name` annotation updated to cluster name, which means that Helm will see those resources as they are deployed by cluster-aws, and then cluster-aws can continue updating them.

Cluster migration steps are:
- Update cluster to the latest version of default-apps-azure (with this change). Nothing should change as the `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` is disabled by default.
- Update `.Values.deleteOptions.moveAppsHelmOwnershipToClusterAzure` to `true`. Verify that all App resources and ConfigMaps from default-apps-azure have `helm.sh/resource-policy: keep` annotation set.
- Delete `<cluster name>-default-apps` App. Verify that all resources from default-apps-azurehave their `meta.helm.sh/release-name` annotation updated to `<cluster name>`.
- Update cluster to the latest version of cluster-azure (new TBA release with this change https://github.com/giantswarm/cluster-azure/pull/290).



Similar to: https://github.com/giantswarm/default-apps-aws/pull/463

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Trigger e2e tests

<!--
If for some reason you want to skip the e2e tests, remove the following lines.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites